### PR TITLE
✨ feat: Add support for Dart packages + Ruby Gems

### DIFF
--- a/index.js
+++ b/index.js
@@ -110,6 +110,7 @@ const run = async () => {
   await go_deps();
   await rust_crates();
   await dart_packages();
+  await ruby_gems();
   await open();
   shell.exit(200);
 };
@@ -245,6 +246,26 @@ const dart_packages = () => {
       shell.exec(`dart pub get`, () => {
         depSpin.stop();
         console.log("\nDart packages got installed\n".bgGreen.white);
+        shell.cd("..");
+        resolve();
+      });
+    }
+  });
+};
+
+const ruby_gems = () => {
+  return new Promise((resolve) => {
+    shell.cd(`${appname}`);
+    if (!shell.test("-f", "Gemfile")) {
+      console.log(`\nCan't find Gemfile in the root directory\n`.yellow);
+      shell.cd("..");
+      resolve();
+    } else {
+      console.log("\nRuby gems are being installed...".bgMagenta.white);
+      depSpin.start();
+      shell.exec(`bundle install`, () => {
+        depSpin.stop();
+        console.log("\nRuby gems got installed\n".bgGreen.white);
         shell.cd("..");
         resolve();
       });


### PR DESCRIPTION
- [x] This PR resolves the Dart support from #23 
Cloner now looks for pubspec.yaml inside the root directory, if found then it installs all the dart packages from pubspec.yaml.
- [x] This PR resolves the Ruby support from #23 
Cloner now looks for Gemfile inside the root directory, if found then it installs all the dart packages from Gemfile.
